### PR TITLE
Remove country from geo location spec

### DIFF
--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -29,13 +29,12 @@
     }
   },
   "geo": [
-    "country",
     "health_zone"
   ],
   "defaults": {
     "colorBy": "health_zone",
     "geoResolution": "health_zone"
-  },  
+  },
   "maintainer": [
     "Catherine Pratt",
     ""


### PR DESCRIPTION
The reason the map on the current page has a bunch of white space is because the lat/long of `Democratic_Republic_of_the_Congo` is specified here: https://github.com/inrb-drc/ebola-nord-kivu/blob/master/auspice/ebola-nord-kivu_meta.json#L112. This happens because `country` is specified as a `geo` option. This allows:

https://nextstrain.org/community/inrb-drc/ebola-nord-kivu?r=country

but this isn't so interesting anyway. If you remove `country` from `geo` options, the resulting view defaults to a nicer set of bounds.

<img width="943" alt="Screen Shot 2019-07-11 at 3 03 07 PM" src="https://user-images.githubusercontent.com/1176109/61088346-09e3a000-a3ed-11e9-9c04-ce2282f160f6.png">

You should be able to just merge this in and rerun to fix.