### PR TITLE
Don't delete data/ when running snakemake clean

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -191,7 +191,6 @@ rule export:
 rule clean:
     message: "Removing directories: {params}"
     params:
-        "data "
         "results ",
         "auspice"
     shell:


### PR DESCRIPTION
It's often useful to be able to just run `snakemake clean` to get rid of everything in `results/` and `auspice/` ahead of calling `snakemake`. However, `data/` was included in the `clean` rule. This could accidentally delete important data files. Better to leave `data/` out of the clean rule.